### PR TITLE
Loosen dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  "httpx~=0.23",
+  "httpx>=0.23,<1",
   "anyio~=3.0",
   "msgpack~=1.0",
   "fasteners>=0.16.3,<0.18.0",
-  "attrs>=21.4,<23.0",
+  "attrs>=21.4,<24.0",
   "aiorwlock~=1.2"
 ]
 


### PR DESCRIPTION
Hi!

Thanks for the work on this very helpful library.

I'm running into some conflicts on `attrs`. I'm not sure what that is: any objections to bumping it?

Also, I'm not sure how the `~=`  operator is supposed to work in pre v1.0, but in the [conda feedstock](https://github.com/conda-forge/httpx-cache-feedstock/blob/main/recipe/meta.yaml#L26), `httpx~=0.23` gets translated to `>=0.23,<0.24`. Is this really what we want? I imagine `httpx` will increment more often than `httpx-cache` and it's reasonable to assume that most changes won't break `httpx-cache`? 

Thanks!
Ludovic